### PR TITLE
fix installation issue on macOS; update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ ssh client wrapper for automatic login.
 ## install
 
 ```shell
-go get github.com/lixvbnet/sshw
+go install github.com/lixvbnet/sshw@latest
 ```
 
 or download pre-compiled binaries from [Releases](https://github.com/lixvbnet/sshw/releases) page.

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,9 @@ module github.com/lixvbnet/sshw
 go 1.15
 
 require (
+	github.com/manifoldco/promptui v0.8.0
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
+	golang.org/x/sys v0.2.0 // indirect
 	golang.org/x/term v0.0.0-20201117132131-f5c789dd3221
 	gopkg.in/yaml.v2 v2.4.0
-	github.com/manifoldco/promptui v0.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=


### PR DESCRIPTION
Hi Lix,
This PR intends to fix an installation issue on macOS.

Install using `go install` reports error:

```
//go:linkname must refer to declared function or variable
```

Refer to the answers [here](https://stackoverflow.com/questions/71507321/go-1-18-build-error-on-mac-unix-syscall-darwin-1-13-go253-golinkname-mus), it needs a dependency which is `golang.org/x/sys`.

After adding it into go mod & sum, UTs passed on Linux (Arch Linux with go 1.19 installed), didn't test on macOS yet.

Please help check it, thanks.

I also updated the install instruction in README.
